### PR TITLE
Add support for PKCS#7 padding

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -112,8 +112,9 @@ Ruby >=1.9 introduces string encodings. The current workaround uses
 #ord and #chr but this is not very satisfactory: it would be preferable
 to move to byte arrays throughout.
 
-The only padding mechanisms implemented are "none", zero byte, and
-ISO 10126-2. PKCS#5/7 padding is not implemented.  Zero byte padding
+The only padding mechanisms implemented are "none", zero byte,
+ISO 10126-2, and PKCS#7. PKCS#5 is not implemented, but can be achieved
+by using PKCS#7 with a BLOCK_SIZE equal to 8. Zero byte padding
 has a well-known failure mode: if the plaintext terminates in null bytes
 then these may be erroneously removed when un-padding is performed.
 

--- a/lib/twofish.rb
+++ b/lib/twofish.rb
@@ -301,7 +301,7 @@ class Twofish
   # hash as follows:
   #   :mode => :ecb (default) or :cbc
   #   :iv => optional 16 byte initialization vector (randomly generated if not supplied)
-  #   :padding => :none (default), :zero_byte or :iso10126_2
+  #   :padding => :none (default), :zero_byte, :iso10126_2 or :pkcs7
   def initialize(key_string, opts={})
 
     self.mode = opts[:mode] # use setter for validation
@@ -456,7 +456,8 @@ class Twofish
 
   # Set the padding scheme for the (CBC mode) cipher
   # (Padding::NONE == :none, Padding::ZERO_BYTE ==
-  # :zero_byte, Padding::ISO10126_2 == :iso10126_2).
+  # :zero_byte, Padding::ISO10126_2 == :iso10126_2,
+  # Padding::PKCS7 == :pkcs7).
   def padding=(scheme)
     @padding = Padding.validate(scheme)
   end

--- a/lib/twofish/padding.rb
+++ b/lib/twofish/padding.rb
@@ -20,8 +20,11 @@ class Twofish
     # Use ISO 10126-2 padding.
     ISO10126_2 = :iso10126_2
 
+    # Use PKCS7 byte padding.
+    PKCS7 = :pkcs7
+
     # Array of all known paddings.
-    ALL = [ NONE, ZERO_BYTE, ISO10126_2 ]
+    ALL = [ NONE, ZERO_BYTE, ISO10126_2, PKCS7 ]
 
     # Default padding (none).
     DEFAULT = NONE
@@ -60,6 +63,9 @@ class Twofish
           # The last byte specify the total pad byte size
           bytes << number_of_pad_bytes
           plaintext << bytes.pack("C*")
+      when PKCS7
+        padding_length = (block_size - remainder - 1) % block_size + 1
+        plaintext << [padding_length].pack('C*') * padding_length
       end
     end
 
@@ -79,6 +85,10 @@ class Twofish
       when ISO10126_2
         number_of_pad_bytes = plaintext.bytes.to_a[plaintext.length-1]
         plaintext[0, (plaintext.length - number_of_pad_bytes)]
+      when PKCS7
+        # the padding length equals to the codepoint of the last char
+        padding_length = plaintext[-1..-1].unpack('C*')[0]
+        plaintext[0..(-1 * (padding_length + 1))]
       end
     end
   end

--- a/test/test_twofish.rb
+++ b/test/test_twofish.rb
@@ -288,6 +288,17 @@ class TestPadding < TestBasics
     assert_equal(:iso10126_2, tf.padding)
   end
 
+  def test_cipher_pkcs7_padding
+    tf = Twofish.new(NULL_KEY_16_BYTES)
+    tf.padding = :pkcs7
+    assert_equal(:pkcs7, tf.padding)
+  end
+
+  def test_cipher_pkcs7_padding_constructor
+    tf = Twofish.new(NULL_KEY_16_BYTES, :padding => :pkcs7)
+    assert_equal(:pkcs7, tf.padding)
+  end
+
   def test_cipher_unknown_padding
     tf = Twofish.new(NULL_KEY_16_BYTES)
     assert_raise ArgumentError do
@@ -346,6 +357,28 @@ class TestPadding < TestBasics
     assert_equal(to_pad.length + BLOCK_SIZE, padded_text.length)
     assert_match(/\A#{to_pad}/, padded_text)
     assert_equal(to_pad, Twofish::Padding::unpad(padded_text, BLOCK_SIZE, :iso10126_2))
+  end
+
+  def test_pad_unpad_pkcs7
+
+    # message containing BLOCK_SIZE bytes
+    m = 'abcdefghijklmnop'
+    
+    (1..BLOCK_SIZE).each { |length|
+
+      # message containing length bytes (1 <= length <= BLOCK_SIZE)
+      to_pad = m[0..(length - 1)]
+      
+      # pad
+      padded_text = Twofish::Padding::pad(to_pad, BLOCK_SIZE, :pkcs7)
+      padding_length = BLOCK_SIZE - (length % BLOCK_SIZE)
+      assert_equal(to_pad + (padding_length.chr * padding_length), padded_text)
+      
+      # unpad
+      assert_equal(to_pad, Twofish::Padding::unpad(padded_text, BLOCK_SIZE, :pkcs7))
+
+    }
+
   end
 
 end


### PR DESCRIPTION
Add support for PKCS#7 padding scheme.
Reference : http://en.wikipedia.org/wiki/Padding_(cryptography)#PKCS7
